### PR TITLE
Fix installation script - Restrict pip version to below 23 during setuptools upgrade

### DIFF
--- a/scripts/install_onedep.sh
+++ b/scripts/install_onedep.sh
@@ -760,7 +760,7 @@ if [[ $OPT_DO_RUNUPDATE == true || $OPT_DO_BUILD_DEV == true ]]; then
   source $VENV_PATH/bin/activate
 
   show_info_message "updating setuptools and pip"
-  pip install --no-cache-dir --upgrade setuptools pip
+  pip install --no-cache-dir --upgrade setuptools "pip<23"
 
   show_info_message "install some base packages"
   pip install wheel


### PR DESCRIPTION
## Fix pip version compatibility in OneDep installation script

### Problem
The OneDep installation script was failing during the setuptools upgrade phase due to compatibility issues with newer versions of pip (23+). These newer versions removed the `--global-option` flag that is required by some legacy package installations in the OneDep build process.

### Solution
This PR restricts pip to versions below 23 during the setuptools upgrade step to maintain compatibility with the existing OneDep build infrastructure.

### Changes
- Modified install_onedep.sh to pin pip version to `<23` during the virtual environment setup
- Added version constraint: `pip install --no-cache-dir --upgrade setuptools "pip<23"`

### Testing
- [ ] Verified OneDep installation completes successfully with the version constraint
- [ ] Confirmed no breaking changes to existing functionality

### Impact
This is a minimal, targeted fix that ensures installation stability while maintaining backward compatibility. The version constraint only affects the installation process and does not impact runtime functionality.
